### PR TITLE
DeviceIndependentBitmap: read color data

### DIFF
--- a/library/Objects/DeviceIndependentBitmap.cs
+++ b/library/Objects/DeviceIndependentBitmap.cs
@@ -73,6 +73,10 @@ namespace Oxage.Wmf.Objects
 			else if (this.DIBHeaderInfo is BitmapInfoHeader)
 			{
 				var header = this.DIBHeaderInfo as BitmapInfoHeader;
+				var colors = (int)header.ColorUsed;
+				if (colors == 0) colors = 1 << (int)header.BitCount;
+				Colors = reader.ReadBytes(colors * 4);
+
 				switch (header.Compression)
 				{
 					case Compression.BI_RGB:


### PR DESCRIPTION
Without this, DIBs are read incorrectly: part of the color palette gets mixed with the actual file data, and last bytes from the data get completely lost.

This closes https://github.com/papnkukn/wmf/issues/3 (I've checked with the file I've posted there, and it now reads correctly, and it's possible to extract the DIB and render it separately, if required).

Also, I am a bit confused about the library development. It looks like the only NuGet got published from this repo, but there are some problems:
- This repo has the issues closed (so I had to open an issue upstream).
- It's unclear what's being maintained and what's not.
- The branch structure of this repositry is a bit confusing. It wasn't easy to find the right branch to send a PR.

Have you considered sending your valuable contributions upstream? Or have you considered maybe opening the issues on your fork? I'd be happy with either.

While we are at it, thank you for making this available on nuget.org, it helped me a lot!